### PR TITLE
test: add test script for running Ladybird tests with optional coverage

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,20 @@
+set -e
+
+echo "Running Ladybird tests..."
+
+if [! -d "build"]; then
+echo "No build folder found. Run ./scripts/build.sh first."
+exit 1
+fi
+
+cd build
+
+ctest --output-on-failure || true
+
+if command -v lcov &> /dev/null; then
+echo "Collecting coverage..."
+lcov --directory . --capture --output-file coverage.info || true
+genhtml coverage.info --output-directory coverage-report || true
+fi
+
+echo "Test completed."


### PR DESCRIPTION
## Summary
- Added `scripts/test.sh` to run Ladybird tests after build.
- Script uses `ctest` to execute unit tests.
- Optional coverage collection via `lcov` if available.

## How to test
1. Run: ./scripts/build.sh
2. Run: ./scripts/test.sh
3. If lcov is installed, coverage report is generated in `coverage-report/`.

## Evidence
- Screenshot of running ./scripts/test.sh (to be attached in report)
- Coverage report (if generated)
